### PR TITLE
Improve register_test by cleaning the pre-state 

### DIFF
--- a/src/PyMIPS/Datastructure/data_model.py
+++ b/src/PyMIPS/Datastructure/data_model.py
@@ -84,6 +84,10 @@ class RegisterPool:
             RegisterPool.__registers[name] = reg
             return reg
 
+    @staticmethod
+    def reset():
+        RegisterPool.__registers = {"$zero": Register("$zero")}
+
 
 def create_immediate(value) -> Immediate:
     try:

--- a/src/PyMIPS/tests/register_test.py
+++ b/src/PyMIPS/tests/register_test.py
@@ -2,6 +2,7 @@ from PyMIPS.Datastructure.data_model import RegisterPool as rp
 
 
 def test_setting_to_num():
+    rp.reset()
     t1 = rp.get_register("$t1")
     assert t1.get_contents_as_int() == 0
     t1.set_contents_from_int(12)


### PR DESCRIPTION
This PR aims to improve the reliability of test `test_setting_to_num` in `register_test` by resetting the `RegisterPool` class to a clean state by calling the function called `reset`, which is like the existing function `reset` in the class `DataHeap`.

The test can fail in the following way if the `RegisterPool` is not in a clean state.
```
>       assert t1.get_contents_as_int() == 0
E       assert 12 == 0
E        +  where 12 = <bound method Register.get_contents_as_int of Register($t1, 12)>()
E        +    where <bound method Register.get_contents_as_int of Register($t1, 12)> = Register($t1, 12).get_contents_as_int
```