### PR TITLE
Fix flaky src/PyMIPS/tests/register_test.py

### DIFF
--- a/src/PyMIPS/tests/register_test.py
+++ b/src/PyMIPS/tests/register_test.py
@@ -6,3 +6,5 @@ def test_setting_to_num():
     assert t1.get_contents_as_int() == 0
     t1.set_contents_from_int(12)
     assert t1.get_contents_as_int() == 12
+    
+    t1.set_contents_from_int(0)


### PR DESCRIPTION
This PR aims to fix the flaky test `src/PyMIPS/tests/register_test.py`. In previous versions, the test will run into failure when running for multiple times. And the reason is that `t1.__content` didn't get cleared. The test failure can be reproduced by 
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 src/PyMIPS/tests/register_test.py`
Notice that the PR is modifying the test to make it more robust without changing the source code.